### PR TITLE
Add interactive service logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # Skylife
+
+Jednoduchá webová aplikace pro evidenci služeb záchranáře a odesílání zpráv vedení.
+
+## Spuštění
+
+Stačí otevřít soubor `index.html` v libovolném moderním prohlížeči. Není potřeba žádná instalace ani backend.
+
+## Použití aplikace
+
+### Režim služby
+1. Klikněte na **Začít službu**. Pole *Datum* a *Od* se automaticky vyplní aktuálním datem a časem, objeví se pole pro zadání použitých vozidel a tlačítko **Ukončit službu**.
+2. Během služby můžete průběžně vyplňovat pole *Použitá vozidla* (např. `AMB01, RZP03`).
+3. Po ukončení směny stiskněte **Ukončit službu**. Pole *Do* se vyplní aktuálním časem, vypočítá se délka služby a přičte se k týdennímu součtu. V seznamu služeb se zobrazí textový výpis, který lze jedním kliknutím zkopírovat.
+4. Celkový počet hodin se v pondělí automaticky začne počítat od nuly.
+
+### Zpráva vedení
+Ve spodní části stránky je formulář pro odeslání zprávy vedení. Po odeslání se text uloží do `localStorage` a zůstane tak dostupný i po opětovném otevření stránky.
+

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Zápis služeb záchranáře</title>
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
 <style>
 body { padding-top: 20px; }
 pre { white-space: pre-wrap; }
@@ -13,29 +13,28 @@ pre { white-space: pre-wrap; }
 <body>
 <div class="container">
   <h1 class="mb-4">Zápis služeb záchranáře</h1>
+
+  <div id="serviceControls" class="mb-3">
+    <button id="startBtn" class="btn btn-primary">Začít službu</button>
+    <button id="endBtn" class="btn btn-danger d-none">Ukončit službu</button>
+  </div>
+
   <form id="serviceForm" class="row g-3">
     <div class="col-md-3">
       <label class="form-label">Datum</label>
-      <input type="date" id="date" class="form-control" required>
+      <input type="date" id="date" class="form-control" readonly required>
     </div>
     <div class="col-md-3">
       <label class="form-label">Od</label>
-      <input type="time" id="timeStart" class="form-control" required>
+      <input type="time" id="timeStart" class="form-control" readonly required>
     </div>
     <div class="col-md-3">
       <label class="form-label">Do</label>
-      <input type="time" id="timeEnd" class="form-control" required>
+      <input type="time" id="timeEnd" class="form-control" readonly>
     </div>
-    <div class="col-md-6">
+    <div class="col-md-6 d-none" id="vehiclesGroup">
       <label class="form-label">Použitá vozidla</label>
-      <input type="text" id="vehicles" class="form-control" placeholder="např. AMB01, emsheli5">
-    </div>
-    <div class="col-md-6">
-      <label class="form-label">Poznámka</label>
-      <input type="text" id="note" class="form-control">
-    </div>
-    <div class="col-12">
-      <button type="submit" class="btn btn-primary">Přidat službu</button>
+      <input type="text" id="vehicles" class="form-control" placeholder="např. AMB01, RZP03">
     </div>
   </form>
 
@@ -46,11 +45,12 @@ pre { white-space: pre-wrap; }
   <button id="copyBtn" class="btn btn-secondary">Kopírovat výstup</button>
 
   <hr>
+
   <h2>Odeslat zprávu vedení</h2>
   <form id="messageForm">
     <div class="mb-3">
       <label class="form-label">Zpráva</label>
-      <textarea class="form-control" id="message" rows="3" required></textarea>
+      <textarea id="message" class="form-control" rows="3" required></textarea>
     </div>
     <button type="submit" class="btn btn-success">Odeslat</button>
   </form>
@@ -59,7 +59,14 @@ pre { white-space: pre-wrap; }
 <script>
 const logs = [];
 const weekTotals = {};
-const form = document.getElementById('serviceForm');
+
+const dateInput = document.getElementById('date');
+const startInput = document.getElementById('timeStart');
+const endInput = document.getElementById('timeEnd');
+const vehiclesInput = document.getElementById('vehicles');
+const vehiclesGroup = document.getElementById('vehiclesGroup');
+const startBtn = document.getElementById('startBtn');
+const endBtn = document.getElementById('endBtn');
 const output = document.getElementById('logOutput');
 
 function minutesToHM(mins) {
@@ -71,57 +78,79 @@ function minutesToHM(mins) {
 function getMonday(d) {
   const date = new Date(d);
   const day = date.getDay();
-  const diff = (day + 6) % 7; // days since Monday
+  const diff = (day + 6) % 7;
   date.setDate(date.getDate() - diff);
   date.setHours(0,0,0,0);
   return date.toISOString().slice(0,10);
 }
 
-form.addEventListener('submit', e => {
-  e.preventDefault();
-  const date = document.getElementById('date').value;
-  const start = document.getElementById('timeStart').value;
-  const end = document.getElementById('timeEnd').value;
-  const vehicles = document.getElementById('vehicles').value;
-  const note = document.getElementById('note').value;
-  if(!date || !start || !end) return;
+startBtn.addEventListener('click', () => {
+  const now = new Date();
+  dateInput.value = now.toISOString().slice(0,10);
+  startInput.value = now.toTimeString().slice(0,5);
+  vehiclesGroup.classList.remove('d-none');
+  endBtn.classList.remove('d-none');
+});
+
+endBtn.addEventListener('click', () => {
+  const now = new Date();
+  endInput.value = now.toTimeString().slice(0,5);
+
+  const date = dateInput.value;
+  const start = startInput.value;
+  const end = endInput.value;
+  const vehicles = vehiclesInput.value;
+
+  if (!date || !start || !end) return;
+
   const startDate = new Date(`${date}T${start}`);
   const endDate = new Date(`${date}T${end}`);
-  let diff = (endDate - startDate) / 60000; // minutes
-  if(diff < 0) diff += 24*60; // overnight
+  let diff = (endDate - startDate) / 60000;
+  if (diff < 0) diff += 24*60;
+
   const weekKey = getMonday(date);
   weekTotals[weekKey] = (weekTotals[weekKey] || 0) + diff;
-  const entry = {
+
+  logs.push({
     date,
     start,
     end,
     vehicles,
-    note,
     duration: diff,
     weekTotal: weekTotals[weekKey]
-  };
-  logs.push(entry);
+  });
+
   renderLogs();
-  form.reset();
+
+  // reset form
+  vehiclesInput.value = '';
+  vehiclesGroup.classList.add('d-none');
+  endBtn.classList.add('d-none');
+  dateInput.value = '';
+  startInput.value = '';
+  endInput.value = '';
 });
 
 function renderLogs() {
-  output.textContent = logs.map(l => `Datum: ${l.date}\nOd - do: ${l.start}–${l.end}\nPoužitá vozidla: ${l.vehicles}\nPoznámka: ${l.note}\nPočet hodin za danou službu: ${minutesToHM(l.duration)}\nCelkový počet hodin za týden: ${minutesToHM(l.weekTotal)}\n---`).join('\n');
+  output.textContent = logs.map(l =>
+    `Datum: ${l.date}\nOd - do: ${l.start}–${l.end}\nPoužitá vozidla: ${l.vehicles}\nPočet hodin za danou službu: ${minutesToHM(l.duration)}\nCelkový počet hodin za týden: ${minutesToHM(l.weekTotal)}`
+  ).join('\n\n');
 }
 
 document.getElementById('copyBtn').addEventListener('click', () => {
   navigator.clipboard.writeText(output.textContent);
 });
 
-// message form - use mailto
 const messageForm = document.getElementById('messageForm');
 messageForm.addEventListener('submit', e => {
   e.preventDefault();
   const msg = document.getElementById('message').value;
-  const mailLink = `mailto:management@example.com?subject=Zprava%20vedeni&body=${encodeURIComponent(msg)}`;
-  window.location.href = mailLink;
+  const stored = JSON.parse(localStorage.getItem('messages') || '[]');
+  stored.push({date: new Date().toISOString(), text: msg});
+  localStorage.setItem('messages', JSON.stringify(stored));
+  messageForm.reset();
+  alert('Zpráva uložena.');
 });
 </script>
-
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace manual form with start/stop workflow
- compute and display weekly totals
- allow sending messages using localStorage
- document usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68685d5c6de883218f5cd4f848cc62b6