### PR TITLE
Add persistent service logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Stačí otevřít soubor `index.html` v libovolném moderním prohlížeči. Nen
 3. Po ukončení směny stiskněte **Ukončit službu**. Pole *Do* se vyplní aktuálním časem, vypočítá se délka služby a přičte se k týdennímu součtu. V seznamu služeb se zobrazí textový výpis, který lze jedním kliknutím zkopírovat.
 4. Celkový počet hodin se v pondělí automaticky začne počítat od nuly.
 
+Veškeré zadané služby se ukládají do `localStorage`, takže po znovuotevření stránky zůstanou zobrazené stejně jako dříve odeslané zprávy.
+
 ### Zpráva vedení
 Ve spodní části stránky je formulář pro odeslání zprávy vedení. Po odeslání se text uloží do `localStorage` a zůstane tak dostupný i po opětovném otevření stránky.
 

--- a/index.html
+++ b/index.html
@@ -60,6 +60,15 @@ pre { white-space: pre-wrap; }
 const logs = [];
 const weekTotals = {};
 
+// Load previously stored logs and totals
+const storedLogs = JSON.parse(localStorage.getItem('serviceLogs') || '[]');
+const storedTotals = JSON.parse(localStorage.getItem('serviceWeekTotals') || '{}');
+logs.push(...storedLogs);
+Object.assign(weekTotals, storedTotals);
+
+// Display stored services on load
+renderLogs();
+
 const dateInput = document.getElementById('date');
 const startInput = document.getElementById('timeStart');
 const endInput = document.getElementById('timeEnd');
@@ -135,6 +144,8 @@ function renderLogs() {
   output.textContent = logs.map(l =>
     `Datum: ${l.date}\nOd - do: ${l.start}–${l.end}\nPoužitá vozidla: ${l.vehicles}\nPočet hodin za danou službu: ${minutesToHM(l.duration)}\nCelkový počet hodin za týden: ${minutesToHM(l.weekTotal)}`
   ).join('\n\n');
+  localStorage.setItem('serviceLogs', JSON.stringify(logs));
+  localStorage.setItem('serviceWeekTotals', JSON.stringify(weekTotals));
 }
 
 document.getElementById('copyBtn').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- load service logs and weekly totals from `localStorage`
- persist service logs and weekly totals when rendered
- render saved logs on page load
- document log persistence

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68685e5bebf08321a63621d94a683b49